### PR TITLE
tooling to help with key rotation

### DIFF
--- a/cmd/assume.go
+++ b/cmd/assume.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -11,6 +12,8 @@ import (
 	"github.com/sjenning/sts-preflight/pkg/cmd/create"
 	"github.com/spf13/cobra"
 )
+
+var assumeDir string
 
 // assumeCmd represents the assume command
 var assumeCmd = &cobra.Command{
@@ -24,6 +27,7 @@ var assumeCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(assumeCmd)
 
+	rootCmd.PersistentFlags().StringVar(&assumeDir, "dir", "_output", "Directory containing generated token")
 	// assumeCmd.PersistentFlags().String("foo", "", "A help for foo")
 }
 
@@ -31,7 +35,8 @@ func execute() {
 	var state create.State
 	state.Read()
 
-	tokenBytes, err := ioutil.ReadFile("_output/token")
+	tokenFilePath := filepath.Join(assumeDir, "token")
+	tokenBytes, err := ioutil.ReadFile(tokenFilePath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	outputDir = "_output"
+)
+
 var (
 	createConfig create.Config
 	createState  create.State
@@ -19,12 +23,12 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates STS infrastructure in AWS",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Mkdir("_output", 0700)
+		os.Mkdir(outputDir, 0700)
 
 		createState.InfraName = createConfig.InfraName
 		createState.Region = createConfig.Region
-		rsa.New()
-		jwks.New(&createState)
+		rsa.New(outputDir)
+		jwks.New(&createState, outputDir)
 		s3endpoint.New(createConfig, &createState)
 		createState.Write()
 	},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	outputDir = "_output"
-)
-
 var (
 	createConfig create.Config
 	createState  create.State
@@ -23,12 +19,12 @@ var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Creates STS infrastructure in AWS",
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Mkdir(outputDir, 0700)
+		os.Mkdir(createConfig.TargetDir, 0700)
 
 		createState.InfraName = createConfig.InfraName
 		createState.Region = createConfig.Region
-		rsa.New(outputDir)
-		jwks.New(&createState, outputDir)
+		rsa.New(createConfig.TargetDir)
+		jwks.New(&createState, createConfig.TargetDir)
 		s3endpoint.New(createConfig, &createState)
 		createState.Write()
 	},
@@ -43,4 +39,6 @@ func init() {
 
 	createCmd.PersistentFlags().StringVar(&createConfig.Region, "region", "", "AWS region were the s3 OIDC endpoint will be created")
 	createCmd.MarkPersistentFlagRequired("region")
+
+	createCmd.PersistentFlags().StringVar(&createConfig.TargetDir, "dir", "_output", "Directory to read/write manifests into")
 }

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -7,13 +7,14 @@ import (
 )
 
 var tokenConfig token.Config
+var tokenDir string
 
 // tokenCmd represents the token command
 var tokenCmd = &cobra.Command{
 	Use:   "token",
 	Short: "Creates a token signed by the RSA private key and validated by the OIDC provider",
 	Run: func(cmd *cobra.Command, args []string) {
-		jwt.New(tokenConfig)
+		jwt.New(tokenConfig, tokenDir)
 	},
 }
 
@@ -21,4 +22,5 @@ func init() {
 	rootCmd.AddCommand(tokenCmd)
 
 	tokenCmd.PersistentFlags().Int64Var(&tokenConfig.ExpireSeconds, "expire-seconds", 3600, "Token expiration duration in seconds")
+	tokenCmd.PersistentFlags().StringVar(&tokenDir, "dir", "_output", "Directory to place generated token into")
 }

--- a/pkg/cmd/create/config.go
+++ b/pkg/cmd/create/config.go
@@ -4,16 +4,18 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 )
 
 const (
-	stateFile = "_output/state.json"
+	stateFile = "state.json"
 )
 
 type Config struct {
 	InfraName               string
 	Region                  string
 	CredentialsRequestsFile string
+	TargetDir               string
 }
 
 type State struct {
@@ -21,6 +23,7 @@ type State struct {
 	Region    string `json:"region"`
 	Kid       string `json:"kid"`
 	RoleARN   string `json:"roleARN"`
+	TargetDir string `json:"targetDir"`
 }
 
 func (s *State) Write() {
@@ -28,14 +31,17 @@ func (s *State) Write() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = ioutil.WriteFile(stateFile, jsonBytes, 0600)
+
+	stateFilePath := filepath.Join(s.TargetDir, stateFile)
+	err = ioutil.WriteFile(stateFilePath, jsonBytes, 0600)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
 func (s *State) Read() {
-	jsonBytes, err := ioutil.ReadFile(stateFile)
+	stateFilePath := filepath.Join(s.TargetDir, stateFile)
+	jsonBytes, err := ioutil.ReadFile(stateFilePath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/keys/config.go
+++ b/pkg/cmd/keys/config.go
@@ -1,0 +1,6 @@
+package keys
+
+type Config struct {
+	ExistingKeysJSONFile string
+	TargetDir            string
+}

--- a/pkg/cmd/keys/generate.go
+++ b/pkg/cmd/keys/generate.go
@@ -1,0 +1,64 @@
+package keys
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	"github.com/sjenning/sts-preflight/pkg/cmd/create"
+	"github.com/sjenning/sts-preflight/pkg/jwks"
+	"github.com/sjenning/sts-preflight/pkg/rsa"
+)
+
+const (
+	privateKey           = "sa-signer"
+	publicKey            = "sa-signer.pub"
+	nextSigningKeySecret = "next-bound-service-account-signing-key"
+)
+
+func GenerateKeys(config Config) {
+	rsa.New(config.TargetDir)
+
+	jwks.New(&create.State{}, config.TargetDir)
+
+	if config.ExistingKeysJSONFile != "" {
+		jwks.MergeKeys(config.ExistingKeysJSONFile, config.TargetDir)
+	}
+}
+
+func GenerateSecret(config Config) {
+	secretTemplate := `apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: %s
+  namespace: openshift-kube-apiserver-operator
+data:
+  service-account.key: %s
+  service-account.pub: %s`
+
+	privateKeyPath := filepath.Join(config.TargetDir, privateKey)
+	publicKeyPath := filepath.Join(config.TargetDir, publicKey)
+
+	privateKeyData, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		log.Fatalf("Failed to read in private key: %s", err)
+	}
+
+	publicKeyData, err := ioutil.ReadFile(publicKeyPath)
+	if err != nil {
+		log.Fatalf("Failed to read in public key: %s", err)
+	}
+
+	privateBase64 := base64.StdEncoding.EncodeToString(privateKeyData)
+	publicBase64 := base64.StdEncoding.EncodeToString(publicKeyData)
+
+	secretData := fmt.Sprintf(secretTemplate, nextSigningKeySecret, privateBase64, publicBase64)
+
+	nextSecretFile := filepath.Join(config.TargetDir, nextSigningKeySecret)
+	if err := ioutil.WriteFile(nextSecretFile, []byte(secretData), 0600); err != nil {
+		log.Fatalf("Failed to save Secret with next signing key data: %s", err)
+	}
+}

--- a/pkg/jwt/jwt.go
+++ b/pkg/jwt/jwt.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -12,11 +13,12 @@ import (
 	"github.com/sjenning/sts-preflight/pkg/cmd/token"
 )
 
-func New(config token.Config) {
+func New(config token.Config, tokenDir string) {
 	var state create.State
 	state.Read()
 
-	privateKey, err := ioutil.ReadFile("_output/sa-signer")
+	privateKeyPath := filepath.Join(tokenDir, "sa-signer")
+	privateKey, err := ioutil.ReadFile(privateKeyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -40,7 +42,7 @@ func New(config token.Config) {
 		log.Fatal(err)
 	}
 
-	tokenFile := "_output/token"
+	tokenFile := filepath.Join(tokenDir, "token")
 	f, err := os.Create(tokenFile)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Add `keys` subcommand which will generate a new ServiceAccount signing key and the OIDC keys.json and the kube Secret to start the key rotation.

Allow bringing an existing keys.json (with `--merge-with-keys-json`) that we can append the newly generated key data to the keys.json (so that it can then be uploaded to wherever the OIDC configuration is stored.

Key rotation would involve:
download the current keys.json
sts-preflight keys --dir newkeysdir --merge-with-keys-json path/to/current/keys.json
upload the new keys.json (eg `aws s3api put-object --bucket myBucket --key keys.json --body newkeysdir/keys.json ; aws s3api put-object-acl --bucket myBucket --key keys.json --acl public-read`)
Replace the existing ServiceAccount signing key in the cluster (`oc replace -f ./newkeysdir/next-bound-service-account-signing-key`)
Wait for the openshift-kube-apiserver-operator to update each kube-apiserver pod (takes several minutes).

Update the other subcommands to allow specifying a directory besides `_output` (which is still kept as the default).